### PR TITLE
[WIP] use process rather than thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ c.add_notifier :takosan,
 
 Sends notifications to a [Takosan](https://github.com/kentaro/takosan) server, a web-to-Slack gateway. Requires `takosan` gem.
 
-### Threads
+### Multi-Process
 
 ```ruby
-c.in_threads 3
+c.in_processes 3
 ```
 
-You can specify the number of active threads.
+You can specify the number of active processes.
 
 ### Custom Components
 

--- a/lib/puppet_theatre/runner.rb
+++ b/lib/puppet_theatre/runner.rb
@@ -11,14 +11,14 @@ module PuppetTheatre
     end
 
     class Config
-      attr_accessor :hosts, :checkers, :reporters, :notifiers, :threads
+      attr_accessor :hosts, :checkers, :reporters, :notifiers, :processes
 
       def initialize
         @hosts = []
         @checkers = {}
         @reporters = {}
         @notifiers = {}
-        @threads = 1
+        @processes = 1
       end
 
       def hosts_from(klass, opts = {})
@@ -45,8 +45,8 @@ module PuppetTheatre
         @notifiers[opts[:name] || klass.name.split('::')[-1]] = obj
       end
 
-      def in_threads(v)
-        @threads = v
+      def in_processes(v)
+        @processes = v
       end
     end
 
@@ -71,7 +71,7 @@ module PuppetTheatre
     def call
       results = Hash.new {|h, k| h[k] = {} }
 
-      Parallel.map(config(:hosts).sort, in_threads: config(:threads)) do |host|
+      Parallel.map(config(:hosts).sort, in_processes: config(:processes)) do |host|
         config(:checkers).each_pair do |name, checker|
           result =
             begin


### PR DESCRIPTION
When using `c.threads` configration, I had warning bellow.
It seems that `PuppetTheatre::Checkers::Rspec.call` is not thread safe.

```
/home/admin/staging/shared/bundle/ruby/2.0.0/bundler/gems/puppet-theatre-39bbae40ddf8/lib/puppet_theatre/checkers/rspec.rb:50: warning: conflicting chdir during another chdir block
```

To avoid it, we should use multi-process rather than thread.